### PR TITLE
Починил рендер маркдауна

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "wirenboard",
   "displayName": "MDX Preview",
   "description": "Preview MDX-style markdown with components for Wiren Board",
-  "version": "0.5.2",
+  "version": "0.4.5",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/templates/frontmatter.html
+++ b/templates/frontmatter.html
@@ -1,15 +1,16 @@
 <table class="frontmatter-table">
-  {{#each items}}
-    <tr>
-      <th>{{@key}}</th>
-    <td>
-      {{#if (isCover @key)}}
-        <img src="{{this}}" alt="Cover image" class="frontmatter-cover">
-      {{else}}
-        {{this}}
-      {{/if}}
-    </td>
-  </tr>
-  {{/each}}
-</table>
-<h1>{{title}}</h1>
+    {{#each items}}
+      <tr>
+        <th>{{@key}}</th>
+        <td>
+          {{#if (isCover @key)}}
+            <img src="{{this}}" alt="Cover image" class="frontmatter-cover">
+          {{else}}
+            {{this}}
+          {{/if}}
+        </td>
+      </tr>
+    {{/each}}
+  </table>
+  
+  <h1>{{title}}</h1>

--- a/templates/main.html
+++ b/templates/main.html
@@ -6,6 +6,6 @@
   <style>{{styles}}</style>
 </head>
 <body>
-  {{{content}}} <!-- Тройные скобки для вывода без экранирования -->
+  {{md content}}
 </body>
 </html>


### PR DESCRIPTION
Сломал рендер первого блока при добавлении обработки frontmatter, теперь починил.

___________________________________
**Что происходит; кому и зачем нужно:**
Починил рендер первого за frontmatter блока.

___________________________________
**Что поменялось для пользователей:**
Первая строка под заголовком теперь корректно рендерится.

___________________________________
**Как проверял/а:**
Поставил плагин, смотрел глазами.

