### PR TITLE
Починил рендер фото если передано число без px.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "wirenboard",
   "displayName": "MDX Preview",
   "description": "Preview MDX-style markdown with components for Wiren Board",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "engines": {
     "vscode": "^1.85.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ const componentRenderers: Record<string, ComponentRenderer> = {
       src: resolveRelativePath(webview, docUri, attrs.src),
       alt: attrs.alt || '',
       caption: attrs.caption,
-      width: attrs.width,
+      width: normalizeSize(attrs.width, '500px'),
       floatClass: attrs.float ? `float-${attrs.float}` : ''
     });
   },


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Починил рендер одиночного фото если нет px в ширине.

___________________________________
**Что поменялось для пользователей:**
Теперь похожее поведение как на сайте.

___________________________________
**Как проверял/а:**
Глазами в vscode.

