### PR TITLE
Добавил масштабирование ширины подписи у одиночного фото.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ const componentRenderers: Record<string, ComponentRenderer> = {
       src: resolveRelativePath(webview, docUri, attrs.src),
       alt: attrs.alt || '',
       caption: attrs.caption,
-      width: normalizeSize(attrs.width, '500px'),
+      width: normalizeSize(attrs.width, '100%'),
       floatClass: attrs.float ? `float-${attrs.float}` : ''
     });
   },

--- a/templates/photo.html
+++ b/templates/photo.html
@@ -1,4 +1,4 @@
-<div class="mdx-photo {{floatClass}}">
+<div class="mdx-photo {{floatClass}}" {{#if width}}style="width:{{width}}"{{/if}}>
   <img src="{{src}}" alt="{{alt}}" {{#if width}}style="width:{{width}}"{{/if}}>
   {{#if caption}}<div class="mdx-photo-caption">{{caption}}</div>{{/if}}
 </div>


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Пофиксил передачу ширины в контейнер одиночного фото. Теперь подпись не расползается.

___________________________________
**Что поменялось для пользователей:**
Стало лучше выглядеть.

___________________________________
**Как проверял/а:**
Поставил расширение, глазами смотрел.

