### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           echo "vsix=dist/${NAME}-${VERSION}.vsix" >> $GITHUB_OUTPUT
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vsix
           path: ${{ steps.package.outputs.vsix }}
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download VSIX artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: vsix
           path: dist/


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Гитхаб ругается:
```
This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

Поднял версию до 4.

___________________________________
**Что поменялось для пользователей:**
Ничего.

___________________________________
**Как проверял/а:**
Вот, проверяю.

